### PR TITLE
Handle watch address changes

### DIFF
--- a/src/account.js
+++ b/src/account.js
@@ -6,17 +6,29 @@ import { sendMessage } from "./messages"
 function account(address) {
   validateAddress(address)
 
+  // lowercase the address
+  address = address.toLowerCase()
+
   // create emitter for transaction
   const emitter = createEmitter()
 
   // create eventCode for transaction
   const eventCode = "accountAddress"
 
-  // put in queue
-  session.accounts.push({
-    address,
-    emitter
-  })
+  const existingAddressWatcher = session.accounts.find(
+    account => account.address === address
+  )
+
+  if (existingAddressWatcher) {
+    // add to existing emitters array
+    existingAddressWatcher.emitters.push(emitter)
+  } else {
+    // put in accounts queue
+    session.accounts.push({
+      address,
+      emitters: [emitter]
+    })
+  }
 
   // logEvent to server
   sendMessage({

--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,19 @@ function sdk(options) {
         eventCode: "checkDappId",
         connectionId
       })
+
+      // re-register all accounts to be watched by server upon
+      // re-connection as they don't get transferred over automatically
+      // to the new connection like tx hashes do
+      session.accounts.forEach(account => {
+        sendMessage({
+          eventCode: "accountAddress",
+          categoryCode: "watch",
+          account: {
+            address: account.address
+          }
+        })
+      })
     }
 
     session.socket.onmessage = handleMessage

--- a/src/messages.js
+++ b/src/messages.js
@@ -91,12 +91,7 @@ export function handleMessage(msg) {
         tx => tx.id === transaction.id || tx.hash === transaction.hash
       )
 
-      const results =
-        hashNotifier &&
-        hashNotifier.emitters.map(emitter => emitter.emit(newState))
-
-      // the emitter result that affects notifications in notify is the result from the latest emitter
-      emitterResult = last(results)
+      emitterResult = hashNotifier && hashNotifier.emitter.emit(newState)
     }
 
     session.transactionListeners &&

--- a/src/messages.js
+++ b/src/messages.js
@@ -1,5 +1,5 @@
 import { session } from "./state"
-import { createEventLog, networkName, serverEcho } from "./utilities"
+import { createEventLog, networkName, serverEcho, last } from "./utilities"
 
 export function sendMessage(msg) {
   session.socket.send(createEventLog(msg))
@@ -50,6 +50,8 @@ export function handleMessage(msg) {
 
   if (event && event.transaction) {
     const { transaction, eventCode, contractCall } = event
+
+    // flatten in to one object
     const newState = { ...transaction, eventCode, contractCall }
 
     // ignore server echo messages
@@ -57,32 +59,45 @@ export function handleMessage(msg) {
       return
     }
 
-    //handle change of hash in speedup and cancel events
+    // handle change of hash in speedup and cancel events
     if (eventCode === "txSpeedUp" || eventCode === "txCancel") {
       session.transactions = session.transactions.map(tx => {
         if (tx.hash === transaction.originalHash) {
+          // reassign hash parameter in transaction queue to new hash
           tx.hash = transaction.hash
         }
         return tx
       })
     }
 
-    const addressNotifier = session.accounts.find(function(a) {
-      return (
-        a.address.toLowerCase() ===
-        (transaction.watchedAddress && transaction.watchedAddress.toLowerCase())
+    const watchedAddress =
+      transaction.watchedAddress && transaction.watchedAddress.toLowerCase()
+
+    let emitterResult
+
+    if (watchedAddress) {
+      const addressNotifier = session.accounts.find(
+        account => account.address === watchedAddress
       )
-    })
 
-    addressNotifier && addressNotifier.emitter.emit(newState)
+      const results =
+        addressNotifier &&
+        addressNotifier.emitters.map(emitter => emitter.emit(newState))
 
-    const hashNotifier = session.transactions.find(function(t) {
-      return t.id === transaction.id || t.hash === transaction.hash
-    })
+      // the emitter result that affects notifications in notify is the result from the latest emitter
+      emitterResult = last(results)
+    } else {
+      const hashNotifier = session.transactions.find(
+        tx => tx.id === transaction.id || tx.hash === transaction.hash
+      )
 
-    const emitterResult = hashNotifier
-      ? hashNotifier.emitter.emit(newState)
-      : false
+      const results =
+        hashNotifier &&
+        hashNotifier.emitters.map(emitter => emitter.emit(newState))
+
+      // the emitter result that affects notifications in notify is the result from the latest emitter
+      emitterResult = last(results)
+    }
 
     session.transactionListeners &&
       session.transactionListeners.forEach(listener =>

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -91,3 +91,7 @@ export function serverEcho(eventCode) {
       return false
   }
 }
+
+export function last(arr) {
+  return arr && arr.reverse()[0]
+}


### PR DESCRIPTION
This PR handles the case where two events are fired for one transaction due to a websocket watching via a hash and address.

closes #10 