### PR TITLE
Enhancement: Match webhook api

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,6 @@ class Blocknative {
       onerror,
       onclose
     } = options
-
     const socket = new SturdyWebSocket(
       apiUrl || 'wss://api.blocknative.com/v0',
       ws

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ class Blocknative {
       onerror,
       onclose
     } = options
+
     const socket = new SturdyWebSocket(
       apiUrl || 'wss://api.blocknative.com/v0',
       ws

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -81,6 +81,7 @@ export type Network =
   | 'goerli'
   | 'kovan'
   | 'xdai'
+  | 'local'
 
 export type Status =
   | 'pending'

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -22,7 +22,9 @@ function waitForConnectionOpen(this: any) {
 }
 
 export function handleMessage(this: any, msg: { data: string }): void {
-  const { status, reason, event, connectionId } = JSON.parse(msg.data)
+  const { status, reason, event, connectionId, serverVersion } = JSON.parse(
+    msg.data
+  )
 
   if (connectionId) {
     if (typeof window !== 'undefined') {
@@ -139,13 +141,21 @@ export function handleMessage(this: any, msg: { data: string }): void {
       this._system === 'ethereum'
         ? {
             ...transaction,
+            serverVersion,
             eventCode,
             timeStamp,
             system,
             network,
             contractCall
           }
-        : { ...transaction, eventCode, timeStamp, system, network }
+        : {
+            ...transaction,
+            serverVersion,
+            eventCode,
+            timeStamp,
+            system,
+            network
+          }
 
     // ignore server echo and unsubscribe messages
     if (serverEcho(eventCode) || transaction.status === 'unsubscribed') {

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -27,15 +27,11 @@ function transaction(this: any, hash: string, id?: string) {
     emitter
   })
 
-  const transaction: BitcoinTransactionLog | EthereumTransactionLog = {
+  const newState = {
     [this._system === 'ethereum' ? 'hash' : 'txid']: hash,
     id: id || hash,
     startTime,
-    status: 'sent'
-  }
-
-  const newState = {
-    ...transaction,
+    status: 'sent',
     eventCode
   }
 
@@ -47,7 +43,7 @@ function transaction(this: any, hash: string, id?: string) {
   })
 
   const transactionObj = {
-    details: transaction,
+    details: newState,
     emitter
   }
 


### PR DESCRIPTION
This PR makes some changes to the payload for each transaction event so that it matches (as closely as possible) the payload that our [Notify API](https://docs.blocknative.com/webhook-api) sends.

The following parameters have been **added**  to the transaction payload:

`serverVersion` - version of the server that sent the payload (`String`)
`timeStamp` - time stamp of when the server sent the payload (`String`)
`system` - system (blockchain) the transaction occurred on (`String`)
`network` - network name the transaction occurred on (`String`)

The following parameters in the transaction payload have been **modified**:

`originalHash` - has been replaced with `replaceHash`
`status` - speedup and cancel events were both represented with a status of `'pending'`, in this update they will be represented with values of `'speedup'` and `'cancel'` respectively

The types interfaces have also been updated in this PR to accurately represent the current server payloads.