### PR TITLE
Hotfix: Rate limit messages based on server response

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-sdk",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "SDK to connect to the blocknative backend via a websocket connection",
   "keywords": [
     "ethereum",

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,3 +12,10 @@ export const networks: { [key: string]: { [key: string]: string } } = {
     '100': 'xdai'
   }
 }
+
+export const DEFAULT_RATE_LIMIT_RULES = {
+  points: 150,
+  duration: 1
+}
+
+export const QUEUE_LIMIT = 10000

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,11 +186,13 @@ function onDown(
 function onReopen(this: any, handler: (() => void) | undefined) {
   this._connected = true
 
-  this._sendMessage({
+  const msg = {
     categoryCode: 'initialize',
     eventCode: 'checkDappId',
     connectionId: this._connectionId
-  })
+  }
+
+  this._socket.send(createEventLog.bind(this)(msg))
 
   // re-register all accounts to be watched by server upon
   // re-connection as they don't get transferred over automatically

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -183,3 +183,8 @@ export interface API {
   unsubscribe: Unsubscribe
   destroy: Destroy
 }
+
+export interface LimitRules {
+  points: number
+  duration: number
+}

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,28 +1,58 @@
-import { serverEcho, last, networkName } from './utilities'
+import { serverEcho, last, networkName, wait } from './utilities'
 import { version } from '../package.json'
 import { Ac, Tx, Emitter, EventObject, TransactionHandler } from './interfaces'
+import { DEFAULT_RATE_LIMIT_RULES, QUEUE_LIMIT } from './config'
 
-export async function sendMessage(this: any, msg: EventObject) {
+export function sendMessage(this: any, msg: EventObject) {
+  if (this._queuedMessages.length > QUEUE_LIMIT) {
+    throw new Error(`Queue limit of ${QUEUE_LIMIT} messages has been reached.`)
+  }
+
+  this._queuedMessages.push(createEventLog.bind(this)(msg))
+
+  if (!this._processingQueue) {
+    this._processQueue()
+  }
+}
+
+export async function processQueue(this: any) {
+  this._processingQueue = true
+
   if (!this._connected) {
     await waitForConnectionOpen.bind(this)()
   }
 
-  this._socket.send(createEventLog.bind(this)(msg))
-}
+  while (this._queuedMessages.length > 0) {
+    // small wait to allow response from server to take affect
+    await wait(1)
 
-function waitForConnectionOpen(this: any) {
-  return new Promise(resolve => {
-    const interval = setInterval(() => {
-      if (this._connected) {
-        setTimeout(resolve, 100)
-        clearInterval(interval)
-      }
-    })
-  })
+    if (this._waitToRetry !== null) {
+      // have been rate limited so wait
+      await this._waitToRetry
+      this._waitToRetry = null
+    }
+
+    const msg = this._queuedMessages.shift()
+
+    const delay = (this._limitRules.duration / this._limitRules.points) * 1000
+    await wait(delay)
+    this._socket.send(msg)
+  }
+
+  this._processingQueue = false
+  this._limitRules = DEFAULT_RATE_LIMIT_RULES
 }
 
 export function handleMessage(this: any, msg: { data: string }): void {
-  const { status, reason, event, connectionId } = JSON.parse(msg.data)
+  const {
+    status,
+    reason,
+    event,
+    connectionId,
+    retryMs,
+    limitRules,
+    blockedMsg
+  } = JSON.parse(msg.data)
 
   if (connectionId) {
     if (typeof window !== 'undefined') {
@@ -34,6 +64,15 @@ export function handleMessage(this: any, msg: { data: string }): void {
 
   // handle any errors from the server
   if (status === 'error') {
+    if (reason.includes('ratelimit')) {
+      this._waitToRetry = wait(retryMs)
+      this._limitRules = limitRules
+
+      // add blocked msg to the front of the queue
+      blockedMsg && this._queuedMessages.unshift(blockedMsg)
+      return
+    }
+
     if (reason.includes('not a valid API key')) {
       if (this._onerror) {
         this._onerror({ message: reason })
@@ -185,7 +224,7 @@ export function handleMessage(this: any, msg: { data: string }): void {
   }
 }
 
-function createEventLog(this: any, msg: EventObject): string {
+export function createEventLog(this: any, msg: EventObject): string {
   return JSON.stringify({
     timeStamp: new Date(),
     dappId: this._dappId,
@@ -195,5 +234,16 @@ function createEventLog(this: any, msg: EventObject): string {
       network: networkName(this._system, this._networkId) || 'local'
     },
     ...msg
+  })
+}
+
+function waitForConnectionOpen(this: any) {
+  return new Promise(resolve => {
+    const interval = setInterval(() => {
+      if (this._connected) {
+        setTimeout(resolve, 100)
+        clearInterval(interval)
+      }
+    })
   })
 }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -92,3 +92,9 @@ export function isTxid(blockchain: string, addressOrHash: string) {
       return false
   }
 }
+
+export function wait(time: number) {
+  return new Promise(resolve => {
+    setTimeout(resolve, time)
+  })
+}


### PR DESCRIPTION
This update adds a message queue for event logs that are sent to the Blocknative server. The queue improves performance and correctly handles rate limits, preventing dropped messages.

When the SDK receives a call to send an event to the server, the event log will get pushed to the end of the `queuedMessages` queue. If the queue isn't currently being processed, then it will start processing event logs.

During processing, an event log will be pulled from the front of the queue and then before sending to the server, it will check whether it needs to wait for some period of time to stay within rate limits that have been enforced by the server.

Once it has looped through and sent all messages in the queue, it will reset the rate limits to the default and finish processing.