### PR TITLE
3.0.0-0.1.0: Add appVersion and appName to WS messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-sdk",
-  "version": "3.0.0",
+  "version": "3.0.0-0.1.0",
   "description": "SDK to connect to the blocknative backend via a websocket connection",
   "keywords": [
     "ethereum",

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,8 @@ import {
   EnhancedConfig
 } from './interfaces'
 
-const DEFAULT_NAME = 'unknown'
+const DEFAULT_APP_NAME = 'unknown'
+const DEFAULT_APP_VERSION = 'unknown'
 const DEFAULT_SYSTEM = 'ethereum'
 
 class Blocknative {
@@ -42,6 +43,8 @@ class Blocknative {
   private _dappId: string
   private _system: string
   private _networkId: number
+  private _appName: string
+  private _appVersion: string
   private _transactionHandlers: TransactionHandler[]
   private _socket: any
   private _connected: boolean
@@ -71,7 +74,8 @@ class Blocknative {
     const {
       dappId,
       system = DEFAULT_SYSTEM,
-      name = DEFAULT_NAME,
+      name = DEFAULT_APP_NAME,
+      appVersion = DEFAULT_APP_VERSION,
       networkId,
       transactionHandlers = [],
       apiUrl,
@@ -112,6 +116,8 @@ class Blocknative {
     this._dappId = dappId
     this._system = system
     this._networkId = networkId
+    this._appName = name
+    this._appVersion = appVersion
     this._transactionHandlers = transactionHandlers
     this._socket = socket
     this._connected = false

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -144,6 +144,7 @@ export interface InitializationOptions {
   dappId: string
   system?: System
   name?: string
+  appVersion?: string
   transactionHandlers?: TransactionHandler[]
   apiUrl?: string
   ws?: any

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -304,6 +304,8 @@ export function createEventLog(this: any, msg: EventObject): string {
       timeStamp: new Date().toISOString(),
       dappId: this._dappId,
       version,
+      appName: this._appName,
+      appVersion: this._appVersion,
       blockchain: {
         system: this._system,
         network: networkName(this._system, this._networkId) || 'local'

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -39,6 +39,7 @@ export function validateOptions(options: any): never | void {
     dappId,
     system,
     name,
+    appVersion,
     networkId,
     transactionHandlers,
     apiUrl,
@@ -57,6 +58,7 @@ export function validateOptions(options: any): never | void {
       'dappId',
       'system',
       'name',
+      'appVersion',
       'networkId',
       'transactionHandlers',
       'apiUrl',
@@ -81,6 +83,12 @@ export function validateOptions(options: any): never | void {
   })
 
   validateType({ name: 'name', value: name, type: 'string', optional: true })
+  validateType({
+    name: 'appVersion',
+    value: appVersion,
+    type: 'string',
+    optional: true
+  })
   validateType({ name: 'networkId', value: networkId, type: 'number' })
 
   validateType({


### PR DESCRIPTION
- Adds optional `appVersion` parameter to SDK initialization to log Onboard and Notify versions
- Sends `appName` and `appVersion` with all messages to server