### PR TITLE
3.3.2-0.0.1: [fix] -Transaction Replace Status Emitter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-sdk",
-  "version": "3.3.2",
+  "version": "3.3.2-0.0.1",
   "description": "SDK to connect to the blocknative backend via a websocket connection",
   "keywords": [
     "ethereum",

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -252,7 +252,7 @@ export function handleMessage(this: any, msg: { data: string }): void {
     // handle change of hash in speedup and cancel events
     if (eventCode === 'txSpeedUp' || eventCode === 'txCancel') {
       this._watchedTransactions = this._watchedTransactions.map((tx: Tx) => {
-        if (tx.hash === transaction.replaceHash) {
+        if (tx.hash === newState.replaceHash) {
           // reassign hash parameter in transaction queue to new hash or txid
           tx.hash = transaction.hash || transaction.txid
         }


### PR DESCRIPTION
- Fixes bug where the transaction hash of a replaced transaction was not getting matched and replaced with the new transaction hash.
Fixes (#122)