### PR TITLE
3.3.3-0.0.1: [fix] account emitter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-sdk",
-  "version": "3.3.3",
+  "version": "3.3.3-0.0.1",
   "description": "SDK to connect to the blocknative backend via a websocket connection",
   "keywords": [
     "ethereum",

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -280,15 +280,15 @@ export function handleMessage(this: any, msg: { data: string }): void {
 
       const configuration = this._configurations.get(watchedAddress)
 
-      const configurationEmitterResult =
-        configuration &&
-        configuration.emitter &&
-        configuration.emitter.emit(newState)
+      const emitterResult =
+        configuration && configuration.emitter
+          ? configuration.emitter.emit(newState) || accountEmitterResult
+          : accountEmitterResult
 
       this._transactionHandlers.forEach((handler: TransactionHandler) =>
         handler({
           transaction: newState,
-          emitterResult: accountEmitterResult || configurationEmitterResult
+          emitterResult
         })
       )
     } else {


### PR DESCRIPTION
The emitter result from the account emitter was being ignored due to the fact that the configuration being undefined was not taken into account.

Fixes notify.js issue blocknative/notify#189