### PR TITLE
3.5.0-0.1.0: [enhancement] - Connect Timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-sdk",
-  "version": "3.5.0",
+  "version": "3.5.0-0.1.0",
   "description": "SDK to connect to the blocknative backend via a websocket connection",
   "keywords": [
     "ethereum",

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,7 @@ class Blocknative {
 
   constructor(options: InitializationOptions) {
     validateOptions(options)
+
     const {
       dappId,
       system = DEFAULT_SYSTEM,
@@ -87,13 +88,17 @@ class Blocknative {
       onclose
     } = options
 
+    // override default timeout to allow for slow connections
+    const timeout = { connectTimeout: 10000 }
+
     const socket = new SturdyWebSocket(
       apiUrl || 'wss://api.blocknative.com/v0',
       ws
         ? {
-            wsConstructor: ws
+            wsConstructor: ws,
+            ...timeout
           }
-        : {}
+        : { ...timeout }
     )
 
     socket.onopen = onOpen.bind(this, onopen)


### PR DESCRIPTION
### Description
Increases the default WebSocket `connectTimeout` from `5000` to `10000`

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
