### PR TITLE
3.7.1-1.0.0: [fix] - Replacement Transactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-sdk",
-  "version": "3.7.1",
+  "version": "3.7.1-0.0.1",
   "description": "SDK to connect to the blocknative backend via a websocket connection",
   "keywords": [
     "ethereum",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-sdk",
-  "version": "3.7.1-0.0.1",
+  "version": "3.7.1-1.0.0",
   "description": "SDK to connect to the blocknative backend via a websocket connection",
   "keywords": [
     "ethereum",


### PR DESCRIPTION
### Description
This PR fixes a bug where the transaction hash on a replacement transaction would be the new transaction, but the rest of the payload would match the original transaction that has been replaced. This is a breaking change that fixes the payload and matches the behaviour of our Webhook notifications.

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
