### PR TITLE
Test whether localStorage is accessible before performing operations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import {
   LimitRules,
   EnhancedConfig
 } from './interfaces'
+import { isLocalStorageAvailable } from './utilities'
 
 const DEFAULT_APP_NAME = 'unknown'
 const DEFAULT_APP_VERSION = 'unknown'
@@ -114,7 +115,7 @@ class Blocknative {
 
     const storageKey = CryptoEs.SHA1(`${dappId} - ${name}`).toString()
     const storedConnectionId =
-      typeof window !== 'undefined' && window.localStorage.getItem(storageKey)
+      isLocalStorageAvailable() && window.localStorage.getItem(storageKey)
 
     this._storageKey = storageKey
     this._connectionId = storedConnectionId || undefined

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -3,7 +3,8 @@ import {
   last,
   networkName,
   wait,
-  jsonPreserveUndefined
+  jsonPreserveUndefined,
+  isLocalStorageAvailable
 } from './utilities'
 import { version } from '../package.json'
 import { Ac, Tx, Emitter, EventObject, TransactionHandler } from './interfaces'
@@ -63,7 +64,7 @@ export function handleMessage(this: any, msg: { data: string }): void {
   } = JSON.parse(msg.data)
 
   if (connectionId) {
-    if (typeof window !== 'undefined') {
+    if (isLocalStorageAvailable()) {
       window.localStorage.setItem(this._storageKey, connectionId)
     }
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -114,3 +114,26 @@ export function wait(time: number) {
 
 export const jsonPreserveUndefined = (k: any, v: any) =>
   v === undefined ? 'undefined' : v
+
+/**
+ * Tests if LocalStorage may be used. Accounts for environments where
+ * LocalStorage is not supported, as well as those where it is blocked.
+ *
+ * @returns `true` if LocalStorage is supported and accessible, `false` otherwise.
+ */
+export function isLocalStorageAvailable(): boolean {
+  const isSupported = typeof window !== 'undefined' && 'localStorage' in window
+
+  if (isSupported) {
+    const testKey = '__testLocalStorage'
+    try {
+      window.localStorage.setItem(testKey, '1')
+      window.localStorage.removeItem(testKey)
+      return true
+    } catch (err) {
+      return false
+    }
+  }
+
+  return false
+}


### PR DESCRIPTION
### Description
Fixes #171. 

This PR adds a utility function that tests whether `window.localStorage` is available and accessible (writeable/readable) before performing operations.

### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
