### PR TITLE
4.2.0-0.1.0 [ feature ] : Mumbai testnet support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-sdk",
-  "version": "4.2.0",
+  "version": "4.2.0-0.1.0",
   "description": "SDK to connect to the blocknative backend via a websocket connection",
   "keywords": [
     "ethereum",

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -12,7 +12,8 @@ export const networks: { [key: string]: { [key: string]: string } } = {
     '56': 'bsc-main',
     '100': 'xdai',
     '137': 'matic-main',
-    '250': 'fantom-main'
+    '250': 'fantom-main',
+    '80001': 'matic-mumbai'
   }
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -124,6 +124,7 @@ export type Network =
   | 'bsc-main'
   | 'matic-main'
   | 'fantom-main'
+  | 'matic-mumbai'
   | 'local'
 
 export type Status =


### PR DESCRIPTION
### Description
adds support for mumbai testnet

ran npm test to test feature works, I also followed a related PR for Matic Main to enable this so feel the change is low risk.

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
