### PR TITLE
4.2.0-0.1.0 [Feature] Error Handling for UNSUPPORTED_CHAIN_MSG

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-sdk",
-  "version": "4.2.0",
+  "version": "4.2.0-0.2.0",
   "description": "SDK to connect to the blocknative backend via a websocket connection",
   "keywords": [
     "ethereum",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-sdk",
-  "version": "4.2.0-0.2.0",
+  "version": "4.2.0-0.1.0",
   "description": "SDK to connect to the blocknative backend via a websocket connection",
   "keywords": [
     "ethereum",

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -178,7 +178,6 @@ export function handleMessage(this: any, msg: { data: string }): void {
     }
 
     if (event.categoryCode === 'simulate') {
-      console.log('You got an error..... ', event)
       simulations$.error(event)
       return
     }

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -86,9 +86,13 @@ export function handleMessage(this: any, msg: { data: string }): void {
       return
     }
 
-    if (event.categoryCode === 'simulate') {
-      simulations$.error(event)
-      return
+    if (reason.includes('upgrade your plan')) {
+      if (this._onerror) {
+        this._onerror({ message: reason })
+        return
+      } else {
+        throw new Error(reason)
+      }
     }
 
     if (reason.includes('not a valid API key')) {
@@ -171,6 +175,12 @@ export function handleMessage(this: any, msg: { data: string }): void {
       } else {
         throw new Error(reason)
       }
+    }
+
+    if (event.categoryCode === 'simulate') {
+      console.log('You got an error..... ', event)
+      simulations$.error(event)
+      return
     }
 
     // handle config error


### PR DESCRIPTION
### Description
This PR introduces an error message when bn-server sends back the `UNSUPPORTED_CHAIN_MSG`. The message is received when the requested `networkId` is not allowed by the users tier. The websocket will close and an error message is returned (introduced in this PR https://github.com/blocknative/bn-server/pull/1273)

This PR also moves the `simulation` error handling further down the file so that unhandled error messages do not get caught at an undefined `event` object. 

Prior to this fix, the SDK will just fail here
```    
if (event.categoryCode === 'simulate') {
      simulations$.error(event)
      return
 }
```

With the fix, end users will see a user friendly error message.

<img width="792" alt="Screen Shot 2022-05-17 at 6 01 03 PM" src="https://user-images.githubusercontent.com/26395088/168925898-1d131bb8-4930-4461-b6cc-03ad2d61af73.png">

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [ ] The box that allows repo maintainers to update this PR is checked (where is this box?)
- [x] I tested locally to make sure this feature/fix works
