### PR TITLE
4.2.0-0.2.0: [enhancement] - Expose Watched Items

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-sdk",
-  "version": "4.2.0-0.1.0",
+  "version": "4.2.0-0.2.0",
   "description": "SDK to connect to the blocknative backend via a websocket connection",
   "keywords": [
     "ethereum",

--- a/src/account.ts
+++ b/src/account.ts
@@ -1,8 +1,9 @@
 import { createEmitter } from './utilities'
 import { Emitter, Ac } from './interfaces'
+import Blocknative from '.'
 
 function account(
-  this: any,
+  this: Blocknative,
   address: string
 ): { emitter: Emitter; details: { address: string } } {
   if (this._destroyed)
@@ -19,7 +20,7 @@ function account(
   // create eventCode for transaction
   const eventCode = 'watch'
 
-  const existingAddressWatcher = this._watchedAccounts.find(
+  const existingAddressWatcher = this.watchedAccounts.find(
     (ac: Ac) => ac.address === address
   )
 
@@ -28,7 +29,7 @@ function account(
     existingAddressWatcher.emitters.push(emitter)
   } else {
     // put in accounts queue
-    this._watchedAccounts.push({
+    this.watchedAccounts.push({
       address,
       emitters: [emitter]
     })

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,10 +1,11 @@
 import { Subject } from 'rxjs'
 import { take, timeout } from 'rxjs/operators'
+import Blocknative from '.'
 import { Config, Emitter } from './interfaces'
 import { createEmitter } from './utilities'
 
 function configuration(
-  this: any,
+  this: Blocknative,
   config: Config
 ): Promise<string | { details: { config: Config }; emitter?: Emitter }> {
   if (this._destroyed) {
@@ -17,18 +18,18 @@ function configuration(
     this._system === 'ethereum' ? config.scope.toLowerCase() : config.scope
 
   // resolve previous configuration if exists
-  const previousConfiguration = this._configurations.get(casedScope)
+  const previousConfiguration = this.configurations.get(casedScope)
 
   previousConfiguration &&
     previousConfiguration.subscription &&
     previousConfiguration.subscription.next()
 
-  const subscription = new Subject()
+  const subscription = new Subject<string>()
 
   // create emitter for transaction
   const emitter = config.watchAddress ? { emitter: createEmitter() } : {}
 
-  this._configurations.set(casedScope, {
+  this.configurations.set(casedScope, {
     ...config,
     ...emitter,
     subscription

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,29 +41,26 @@ const DEFAULT_APP_VERSION = 'unknown'
 const DEFAULT_SYSTEM = 'ethereum'
 
 class Blocknative {
-  private _storageKey: string
-  private _connectionId: string | undefined
-  private _dappId: string
-  private _system: string
-  private _networkId: number
-  private _appName: string
-  private _appVersion: string
-  private _transactionHandlers: TransactionHandler[]
-  private _socket: any
-  private _connected: boolean
-  private _sendMessage: (msg: EventObject) => void
-  private _watchedTransactions: Tx[]
-  private _watchedAccounts: Ac[]
-  private _configurations: Map<string, EnhancedConfig>
-  private _pingTimeout?: NodeJS.Timeout
-  private _heartbeat?: () => void
-  private _destroyed: boolean
-  private _onerror: ((error: SDKError) => void) | undefined
-  private _queuedMessages: EventObject[]
-  private _limitRules: LimitRules
-  private _waitToRetry: null | Promise<void>
-  private _processingQueue: boolean
-  private _processQueue: () => Promise<void>
+  protected _storageKey: string
+  protected _connectionId: string | undefined
+  protected _dappId: string
+  protected _system: string
+  protected _networkId: number
+  protected _appName: string
+  protected _appVersion: string
+  protected _transactionHandlers: TransactionHandler[]
+  protected _socket: any
+  protected _connected: boolean
+  protected _sendMessage: (msg: EventObject) => void
+  protected _pingTimeout?: NodeJS.Timeout
+  protected _heartbeat?: () => void
+  protected _destroyed: boolean
+  protected _onerror: ((error: SDKError) => void) | undefined
+  protected _queuedMessages: EventObject[]
+  protected _limitRules: LimitRules
+  protected _waitToRetry: null | Promise<void>
+  protected _processingQueue: boolean
+  protected _processQueue: () => Promise<void>
 
   public transaction: Transaction
   public account: Account
@@ -72,6 +69,9 @@ class Blocknative {
   public unsubscribe: Unsubscribe
   public destroy: Destroy
   public configuration: Configuration
+  public watchedTransactions: Tx[]
+  public watchedAccounts: Ac[]
+  public configurations: Map<string, EnhancedConfig>
 
   constructor(options: InitializationOptions) {
     validateOptions(options)
@@ -131,9 +131,6 @@ class Blocknative {
     this._socket = socket
     this._connected = false
     this._sendMessage = sendMessage.bind(this)
-    this._watchedTransactions = []
-    this._watchedAccounts = []
-    this._configurations = new Map()
     this._pingTimeout = undefined
     this._destroyed = false
     this._onerror = onerror
@@ -160,6 +157,9 @@ class Blocknative {
     }
 
     // public API
+    this.watchedTransactions = []
+    this.watchedAccounts = []
+    this.configurations = new Map()
     this.transaction = transaction.bind(this)
     this.account = account.bind(this)
     this.event = event.bind(this)
@@ -219,11 +219,11 @@ async function onReopen(this: any, handler: (() => void) | undefined) {
 
   // re-register all configurations on re-connection
   const configurations: EnhancedConfig[] = Array.from(
-    this._configurations.values()
+    this.configurations.values()
   )
 
   // register global config first and wait for it to complete
-  const globalConfiguration = this._configurations.get('global')
+  const globalConfiguration = this.configurations.get('global')
 
   if (globalConfiguration) {
     try {
@@ -256,7 +256,7 @@ async function onReopen(this: any, handler: (() => void) | undefined) {
   // re-register all accounts to be watched by server upon
   // re-connection as they don't get transferred over automatically
   // to the new connection like tx hashes do
-  this._watchedAccounts.forEach((account: Ac) => {
+  this.watchedAccounts.forEach((account: Ac) => {
     this._sendMessage({
       eventCode: 'accountAddress',
       categoryCode: 'watch',

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -277,7 +277,7 @@ export interface SimulationTransaction {
   to: string
   value: number
   gas: number
-  input: string,
+  input: string
   gasPrice?: number
   maxPriorityFeePerGas?: number
   maxFeePerGas?: number
@@ -312,25 +312,68 @@ export interface SimulationTransactionOutput {
 }
 
 export interface Simulate {
-  (system: System, network: Network, transaction: SimulationTransaction): Promise<SimulationTransactionOutput>
+  (
+    system: System,
+    network: Network,
+    transaction: SimulationTransaction
+  ): Promise<SimulationTransactionOutput>
 }
 
-export interface EventObject {
+export type BaseEventObject = {
   eventCode: string
   categoryCode: string
-  transaction?: TransactionEventLog
-  wallet?: {
-    balance: string
-  }
-  contract?: {
+}
+
+export type BaseTransactionEventObject = {
+  startTime?: number
+  status?: string
+  id?: string
+}
+
+export type BitcoinTransactionEventObject = BaseTransactionEventObject & {
+  txid: string
+}
+
+export type EthereumTransactionEventObject = BaseTransactionEventObject & {
+  hash: string
+}
+
+export type TransactionEventObject = BaseEventObject & {
+  transaction:
+    | BitcoinTransactionEventObject
+    | EthereumTransactionEventObject
+    | SimulationTransaction
+}
+
+export type WalletEventObject = BaseEventObject & {
+  balance: { balance: string }
+}
+export type ContractEventObject = BaseEventObject & {
+  contract: {
     methodName: string
     parameters: any[]
   }
-  account?: {
+}
+
+export type AccountEventObject = BaseEventObject & {
+  account: {
     address: string
   }
-  connectionId?: string
 }
+
+export type InitializeEventObject = BaseEventObject & { connectionId: string }
+
+export type ConfigEventObject = BaseEventObject & {
+  config: Config
+}
+
+export type EventObject =
+  | TransactionEventObject
+  | WalletEventObject
+  | ContractEventObject
+  | AccountEventObject
+  | InitializeEventObject
+  | ConfigEventObject
 
 export interface TransactionHandler {
   (transaction: TransactionEvent): void

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -184,7 +184,7 @@ export function handleMessage(this: any, msg: { data: string }): void {
 
     // handle config error
     if (event && event.config) {
-      const configuration = this._configurations.get(event.config.scope)
+      const configuration = this.configurations.get(event.config.scope)
 
       if (configuration && configuration.subscription) {
         configuration.subscription.error({ message: reason })
@@ -208,13 +208,12 @@ export function handleMessage(this: any, msg: { data: string }): void {
         ? event.config.scope.toLowerCase()
         : event.config.scope
 
-    const configuration = this._configurations.get(casedScope)
+    const configuration = this.configurations.get(casedScope)
 
     if (configuration && configuration.subscription) {
       configuration.subscription.next()
     }
   }
-
 
   if (event && event.transaction) {
     const {
@@ -272,7 +271,7 @@ export function handleMessage(this: any, msg: { data: string }): void {
 
     // handle change of hash in speedup and cancel events
     if (eventCode === 'txSpeedUp' || eventCode === 'txCancel') {
-      this._watchedTransactions = this._watchedTransactions.map((tx: Tx) => {
+      this.watchedTransactions = this.watchedTransactions.map((tx: Tx) => {
         if (tx.hash === newState.replaceHash) {
           // reassign hash parameter in transaction queue to new hash or txid
           tx.hash = transaction.hash || transaction.txid
@@ -294,7 +293,7 @@ export function handleMessage(this: any, msg: { data: string }): void {
         : transaction.watchedAddress
 
     if (watchedAddress) {
-      const accountObj = this._watchedAccounts.find(
+      const accountObj = this.watchedAccounts.find(
         (ac: Ac) => ac.address === watchedAddress
       )
 
@@ -306,7 +305,7 @@ export function handleMessage(this: any, msg: { data: string }): void {
           )
         : false
 
-      const configuration = this._configurations.get(watchedAddress)
+      const configuration = this.configurations.get(watchedAddress)
 
       const emitterResult =
         configuration && configuration.emitter
@@ -320,7 +319,7 @@ export function handleMessage(this: any, msg: { data: string }): void {
         })
       )
     } else {
-      const transactionObj = this._watchedTransactions.find(
+      const transactionObj = this.watchedTransactions.find(
         (tx: Tx) => tx.hash === newState.hash || newState.txid
       )
 
@@ -333,7 +332,7 @@ export function handleMessage(this: any, msg: { data: string }): void {
 
       // replace the emitter hash to the replace hash on replacement txs
       if (newState.status === 'speedup' || newState.status === 'cancel') {
-        this._watchedTransactions = this._watchedTransactions.map((tx: Tx) => {
+        this.watchedTransactions = this.watchedTransactions.map((tx: Tx) => {
           if (tx.hash === newState.hash || newState.txid) {
             return { ...tx, hash: newState.replaceHash }
           }

--- a/src/simulate.ts
+++ b/src/simulate.ts
@@ -1,33 +1,46 @@
-import { SimulationTransaction, SimulationTransactionOutput } from './interfaces'
+import {
+  SimulationTransaction,
+  SimulationTransactionOutput
+} from './interfaces'
 import { simulations$ } from './streams'
 import { take, filter } from 'rxjs/operators'
 import { nanoid } from 'nanoid'
+import Blocknative from '.'
 
-
-function simulate(this: any, system: string, network: string, transaction: SimulationTransaction): Promise<SimulationTransactionOutput> {
+function simulate(
+  this: Blocknative,
+  system: string,
+  network: string,
+  transaction: SimulationTransaction
+): Promise<SimulationTransactionOutput> {
   if (this._destroyed)
     throw new Error(
       'The WebSocket instance has been destroyed, re-initialize to continue making requests.'
     )
 
-    // generate a nano ID, add into transaction object, instead of filtering() below, just match the nano id
-    transaction.id = nanoid()
+  // generate a nano ID, add into transaction object, instead of filtering() below, just match the nano id
+  transaction.id = nanoid()
 
-    // send payload to server
-    this._sendMessage({
-      categoryCode: 'simulate',
-      eventCode: 'txSimulation',
-      transaction: transaction
-    })
+  // send payload to server
+  this._sendMessage({
+    categoryCode: 'simulate',
+    eventCode: 'txSimulation',
+    transaction: transaction
+  })
 
-    return new Promise((resolve, reject) => {
-      simulations$.pipe(filter(({ id }) => {
-        return id === transaction.id
-      }), take(1)).subscribe({
-        next: (transaction) => resolve(transaction),
-        error: (event) => reject(event.error.message)
+  return new Promise((resolve, reject) => {
+    simulations$
+      .pipe(
+        filter(({ id }) => {
+          return id === transaction.id
+        }),
+        take(1)
+      )
+      .subscribe({
+        next: transaction => resolve(transaction),
+        error: event => reject(event.error.message)
       })
-    })
+  })
 }
 
 export default simulate

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1,7 +1,8 @@
 import { createEmitter } from './utilities'
 import { Emitter, TransactionHandler } from './interfaces'
+import Blocknative from '.'
 
-function transaction(this: any, hash: string, id?: string) {
+function transaction(this: Blocknative, hash: string, id?: string) {
   if (this._destroyed)
     throw new Error(
       'The WebSocket instance has been destroyed, re-initialize to continue making requests.'
@@ -17,13 +18,15 @@ function transaction(this: any, hash: string, id?: string) {
   const eventCode = 'txSent'
 
   // put in queue
-  this._watchedTransactions.push({
+  this.watchedTransactions.push({
     hash,
     emitter
   })
 
+  const transactionId = this._system === 'ethereum' ? { hash } : { txid: hash }
+
   const transaction = {
-    [this._system === 'ethereum' ? 'hash' : 'txid']: hash,
+    ...transactionId,
     id: id || hash,
     startTime,
     status: 'sent'


### PR DESCRIPTION
### Description
This PR:
- Exposes the lists of watched items (`watchedTransactions`, `watchedAccounts`, `configurations`) to the public API rather than having them marked as private.
- Fixes types so that `this` refers to the `Blocknative` class rather than `any`

These changes are needed to be able to create a multi-chain SDK that automatically closes connections if there are no longer any subscriptions associated with that connection.

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
