### PR TITLE
Release 4.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-sdk",
-  "version": "4.5.0-0.1.0",
+  "version": "4.6.0",
   "description": "SDK to connect to the blocknative backend via a websocket connection",
   "keywords": [
     "ethereum",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-sdk",
-  "version": "4.5.0",
+  "version": "4.5.0-0.1.0",
   "description": "SDK to connect to the blocknative backend via a websocket connection",
   "keywords": [
     "ethereum",

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,9 @@ import {
   SDKError,
   LimitRules,
   EnhancedConfig,
-  MultiChainOptions
+  MultiChainOptions,
+  InitializationOptionsApiUrl,
+  InitializationOptionsDappId
 } from './types'
 
 const DEFAULT_APP_NAME = 'unknown'
@@ -45,7 +47,7 @@ const DEFAULT_SYSTEM = 'ethereum'
 class SDK {
   protected _storageKey: string
   protected _connectionId: string | undefined
-  protected _dappId: string
+  protected _dappId?: string
   protected _system: string
   protected _networkId: number
   protected _appName: string
@@ -80,13 +82,11 @@ class SDK {
     validateOptions(options)
 
     const {
-      dappId,
       system = DEFAULT_SYSTEM,
       name = DEFAULT_APP_NAME,
       appVersion = DEFAULT_APP_VERSION,
       networkId,
       transactionHandlers = [],
-      apiUrl,
       ws,
       onopen,
       ondown,
@@ -94,6 +94,9 @@ class SDK {
       onerror,
       onclose
     } = options
+
+    const { apiUrl } = options as InitializationOptionsApiUrl
+    const { dappId } = options as InitializationOptionsDappId
 
     // override default timeout to allow for slow connections
     const timeout = { connectTimeout: 10000 }

--- a/src/multichain/index.ts
+++ b/src/multichain/index.ts
@@ -7,13 +7,16 @@ import {
   ChainId,
   MultiChainOptions,
   EthereumTransactionData,
-  SDKError
+  SDKError,
+  MultiChainOptionsApiKey,
+  MultiChainOptionsApiUrl
 } from '../types'
 
 //**Experimental API that is not yet finalized and is in BETA*/
 class MultiChain {
   public apiKey: string
-  public ws: WebSocket | void
+  public ws?: any
+  public apiUrl: string
   public connections: Record<ChainId, SDK | null>
   public transactions$: Observable<EthereumTransactionData>
   public errors$: Subject<SDKError>
@@ -24,9 +27,12 @@ class MultiChain {
   protected onTransaction$: Subject<EthereumTransactionData>
 
   constructor(options: MultiChainOptions, Blocknative: typeof SDK) {
-    const { apiKey, ws } = options
+    const { ws } = options
+    const { apiKey } = options as MultiChainOptionsApiKey
+    const { apiUrl } = options as MultiChainOptionsApiUrl
 
     this.apiKey = apiKey
+    this.apiUrl = apiUrl
     this.ws = ws
     this.connections = {}
     this.onTransaction$ = new Subject()

--- a/src/types.ts
+++ b/src/types.ts
@@ -181,19 +181,26 @@ export interface Vout {
   }
 }
 
-export type MultiChainOptions = {
+export type MultiChainOptionsApiKey = {
   apiKey: string
   ws?: any
 }
 
-export type InitializationOptions = {
+export type MultiChainOptionsApiUrl = {
+  apiUrl: string
+  ws?: any
+}
+
+export type MultiChainOptions =
+  | MultiChainOptionsApiUrl
+  | MultiChainOptionsApiKey
+
+export type BaseInitializationOptions = {
   networkId: number
-  dappId: string
   system?: System
   name?: string
   appVersion?: string
   transactionHandlers?: TransactionHandler[]
-  apiUrl?: string
   ws?: any
   onopen?: () => void
   ondown?: (closeEvent: CloseEvent) => void
@@ -201,6 +208,21 @@ export type InitializationOptions = {
   onerror?: (error: SDKError) => void
   onclose?: () => void
 }
+
+export type InitializationOptionsDappId = BaseInitializationOptions & {
+  dappId: string
+  apiUrl?: string
+}
+
+export type InitializationOptionsApiUrl = BaseInitializationOptions & {
+  apiUrl: string
+}
+
+/** Requires a dappId or an apiUrl with the apikey in the query parameter */
+export type InitializationOptions =
+  | InitializationOptionsApiUrl
+  | InitializationOptionsDappId
+
 export interface SDKError {
   message: string
   error?: any

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -74,7 +74,12 @@ export function validateOptions(options: any): never | void {
     'Initialization Options'
   )
 
-  validateType({ name: 'dappId', value: dappId, type: 'string' })
+  validateType({
+    name: 'dappId',
+    value: dappId,
+    type: 'string',
+    optional: true
+  })
 
   validateType({
     name: 'system',


### PR DESCRIPTION
### Description
- Makes `dappId` optional when using `apiUrl`
