### PR TITLE
[4.6.0-0.0.2]: Fix - Create new type for MultiSimOutput, and update SimulationTransactionOutput

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-sdk",
-  "version": "4.6.0-0.0.1",
+  "version": "4.6.0-0.0.2",
   "description": "SDK to connect to the blocknative backend via a websocket connection",
   "keywords": [
     "ethereum",

--- a/src/multi-sim.ts
+++ b/src/multi-sim.ts
@@ -1,13 +1,13 @@
 import { take, filter } from 'rxjs/operators'
 import { nanoid } from 'nanoid'
-import { SimulationTransaction, SimulationTransactionOutput } from './types'
+import { SimulationTransaction, MultiSimOutput } from './types'
 import { simulations$ } from './streams'
 import SDK from '.'
 
 function multiSim(
   this: SDK,
   transactions: SimulationTransaction[]
-): Promise<SimulationTransactionOutput> {
+): Promise<MultiSimOutput> {
   if (this._destroyed)
     throw new Error(
       'The WebSocket instance has been destroyed, re-initialize to continue making requests.'
@@ -32,8 +32,7 @@ function multiSim(
         take(1)
       )
       .subscribe({
-        next: ({ transaction }) =>
-          resolve(transaction as SimulationTransactionOutput),
+        next: ({ transaction }) => resolve(transaction as MultiSimOutput),
         error: ({ error }) => reject(error.message)
       })
   })

--- a/src/multi-sim.ts
+++ b/src/multi-sim.ts
@@ -7,7 +7,7 @@ import SDK from '.'
 function multiSim(
   this: SDK,
   transactions: SimulationTransaction[]
-): Promise<SimulationTransactionOutput[]> {
+): Promise<SimulationTransactionOutput> {
   if (this._destroyed)
     throw new Error(
       'The WebSocket instance has been destroyed, re-initialize to continue making requests.'
@@ -33,7 +33,7 @@ function multiSim(
       )
       .subscribe({
         next: ({ transaction }) =>
-          resolve(transaction as SimulationTransactionOutput[]),
+          resolve(transaction as SimulationTransactionOutput),
         error: ({ error }) => reject(error.message)
       })
   })

--- a/src/streams.ts
+++ b/src/streams.ts
@@ -1,7 +1,7 @@
 import { Subject } from 'rxjs'
-import { SimulationTransactionOutput } from './types'
+import { MultiSimOutput, SimulationTransactionOutput } from './types'
 
 export const simulations$ = new Subject<{
   eventId: string
-  transaction: SimulationTransactionOutput | SimulationTransactionOutput[]
+  transaction: SimulationTransactionOutput | MultiSimOutput
 }>()

--- a/src/types.ts
+++ b/src/types.ts
@@ -322,7 +322,7 @@ export interface SimulationTransactionOutput {
   gasPrice: string
   input: string
   type: number
-  gasUsed: string
+  gasUsed: number
   internalTransactions?: InternalTransaction[]
   netBalanceChanges?: BalanceChange[]
   serverVersion: string
@@ -333,6 +333,22 @@ export interface SimulationTransactionOutput {
   network: Network
   error?: any
   contractCall: ContractCall
+}
+
+export type MultiSimOutput = {
+  id?: string
+  contractCall: ContractCall[]
+  error?: any
+  gasUsed: number[]
+  internalTransactions: InternalTransaction[][]
+  netBalanceChanges: NetBalanceChange[][]
+  network: Network
+  simDetails: SimDetails
+  serverVersion: string
+  system: System
+  status: Status
+  simulatedBlockNumber: number
+  transactions: InternalTransaction[]
 }
 
 export interface Simulate {


### PR DESCRIPTION
### Description
Create new type for MultiSimResponse and update fields in SimulationTransactionOutput to. match what is returned from the server.

<img width="1420" alt="Screen Shot 2022-11-22 at 9 26 37 AM" src="https://user-images.githubusercontent.com/24457880/203368074-2f2c41d0-ba26-416e-a10e-5840abb56f0d.png">

### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [ ] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
