### PR TITLE
4.6.2-0.0.1: Deprecate Unsupported Chains

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-sdk",
-  "version": "4.6.2",
+  "version": "4.6.2-0.0.1",
   "description": "SDK to connect to the blocknative backend via a websocket connection",
   "keywords": [
     "ethereum",

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,21 +1,16 @@
 export const networks: { [key: string]: { [key: string]: string } } = {
-  bitcoin: {
-    '1': 'main',
-    '2': 'testnet'
-  },
   ethereum: {
     '1': 'main',
     '3': 'ropsten',
     '4': 'rinkeby',
     '5': 'goerli',
-    '42': 'kovan',
-    '56': 'bsc-main',
     '100': 'xdai',
     '137': 'matic-main',
-    '250': 'fantom-main',
     '80001': 'matic-mumbai'
   }
 }
+
+export const DEPRECATED_NETWORK_IDS = [2, 42, 56, 250]
 
 export const DEFAULT_RATE_LIMIT_RULES = {
   points: 150,

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,19 +111,15 @@ export interface TransactionEvent {
   transaction: TransactionData | TransactionEventLog
 }
 
-export type System = 'bitcoin' | 'ethereum'
+export type System = 'ethereum'
 
 export type Network =
   | 'main'
-  | 'testnet'
   | 'ropsten'
   | 'rinkeby'
   | 'goerli'
-  | 'kovan'
   | 'xdai'
-  | 'bsc-main'
   | 'matic-main'
-  | 'fantom-main'
   | 'matic-mumbai'
   | 'local'
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,5 +1,5 @@
 import { TransactionHandler } from './types'
-import { networks } from './defaults'
+import { DEPRECATED_NETWORK_IDS, networks } from './defaults'
 
 export function validateType(options: {
   name: string
@@ -96,6 +96,12 @@ export function validateOptions(options: any): never | void {
   })
 
   validateType({ name: 'networkId', value: networkId, type: 'number' })
+
+  if (DEPRECATED_NETWORK_IDS.includes(networkId)) {
+    console.error(
+      `Blocknative SDK: Network with ID: ${networkId} has been deprecated and you will no longer receive transaction events on this network.`
+    )
+  }
 
   validateType({
     name: 'transactionHandler',


### PR DESCRIPTION
### Description
- Deprecates Bitcoin, Kovan, BNB and Fantom chains that will no longer be supported by the Blocknative server

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
