### PR TITLE
4.6.3-0.0.1 - Update: Deprecate Rinkeby and Ropsten networks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-sdk",
-  "version": "4.6.3",
+  "version": "4.6.3-0.0.1",
   "description": "SDK to connect to the blocknative backend via a websocket connection",
   "keywords": [
     "ethereum",

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,8 +1,6 @@
 export const networks: { [key: string]: { [key: string]: string } } = {
   ethereum: {
     '1': 'main',
-    '3': 'ropsten',
-    '4': 'rinkeby',
     '5': 'goerli',
     '100': 'xdai',
     '137': 'matic-main',
@@ -10,7 +8,7 @@ export const networks: { [key: string]: { [key: string]: string } } = {
   }
 }
 
-export const DEPRECATED_NETWORK_IDS = [2, 42, 56, 250]
+export const DEPRECATED_NETWORK_IDS = [2, 3, 4, 42, 56, 250]
 
 export const DEFAULT_RATE_LIMIT_RULES = {
   points: 150,

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,8 +115,6 @@ export type System = 'ethereum'
 
 export type Network =
   | 'main'
-  | 'ropsten'
-  | 'rinkeby'
   | 'goerli'
   | 'xdai'
   | 'matic-main'


### PR DESCRIPTION
### Description
- Deprecates Rinkeby and Ropsten networks as they are no longer supported by the Blocknative server

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
