### PR TITLE
Release 4.6.5 (master)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-sdk",
-  "version": "4.6.4-0.0.1",
+  "version": "4.6.5",
   "description": "SDK to connect to the blocknative backend via a websocket connection",
   "keywords": [
     "ethereum",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-sdk",
-  "version": "4.6.4",
+  "version": "4.6.4-0.0.1",
   "description": "SDK to connect to the blocknative backend via a websocket connection",
   "keywords": [
     "ethereum",

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,6 +130,7 @@ export type Status =
   | 'dropped'
   | 'pending-simulation'
   | 'stuck'
+  | 'simulated'
 
 export interface InputOutput {
   address: string


### PR DESCRIPTION
### Description
Bug fix for:  'simulated' Status type was missing and is used by the Transaction Preview package. This error was found with the addition of new type checks in our W3O publishing pipeline.

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
