### PR TITLE
[security] Replace crypto-es with latest crypto-js v4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-node-resolve": "^7.1.1",
+    "@types/crypto-js": "^4.2.2",
     "@typescript-eslint/eslint-plugin": "^2.30.0",
     "@typescript-eslint/parser": "^2.30.0",
     "babel-plugin-external-helpers": "^6.18.0",
@@ -45,7 +46,7 @@
     "typescript": "^3.6.4"
   },
   "dependencies": {
-    "crypto-es": "^1.2.2",
+    "crypto-js": "^4.2.0",
     "nanoid": "^3.3.1",
     "rxjs": "^6.6.3",
     "sturdy-websocket": "^0.1.12"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-sdk",
-  "version": "4.6.7",
+  "version": "4.7.0",
   "description": "SDK to connect to the blocknative backend via a websocket connection",
   "keywords": [
     "ethereum",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,7 @@ export default [
       dir: 'dist/iife/',
       format: 'iife',
       name: 'bncSdk',
-      globals: ['SturdyWebSocket', 'crypto-es', 'nanoid', 'rxjs']
+      globals: ['SturdyWebSocket', 'crypto-js', 'nanoid', 'rxjs']
     },
     plugins: [
       json(),
@@ -27,7 +27,7 @@ export default [
         dir: 'dist/esm/'
       }
     ],
-    external: ['sturdy-websocket', 'crypto-es', 'nanoid', 'rxjs'],
+    external: ['sturdy-websocket', 'crypto-js', 'nanoid', 'rxjs'],
     plugins: [
       json(),
       resolve(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { validateOptions } from './validation'
 import SturdyWebSocket from 'sturdy-websocket'
-import CryptoEs from 'crypto-es'
+import CryptoJS from 'crypto-js'
 import transaction from './transaction'
 import account from './account'
 import event from './event'
@@ -122,7 +122,7 @@ class SDK {
       onclose && onclose()
     }
 
-    const storageKey = CryptoEs.SHA1(`${dappId} - ${name}`).toString()
+    const storageKey = CryptoJS.SHA1(`${dappId} - ${name}`).toString()
     const storedConnectionId =
       isLocalStorageAvailable() && window.localStorage.getItem(storageKey)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -866,6 +866,11 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/crypto-js@^4.2.2":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-4.2.2.tgz#771c4a768d94eb5922cc202a3009558204df0cea"
+  integrity sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
@@ -1326,10 +1331,10 @@ cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-crypto-es@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/crypto-es/-/crypto-es-1.2.2.tgz#ed36b08af530808dff2214ffe696a2ae62497640"
-  integrity sha512-opab8M4wcsMWMDAMl+2G7inqlVyvAGNsJT8eOQRBOKNqsSFPQ8/WLP9tp0Q7bVxeNp/1e9TWn/x5GmcUVhRDUg==
+crypto-js@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
+  integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
 
 debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"


### PR DESCRIPTION
### Description

This update addresses a crucial security concern in the hashing strategy by altering the default hash algorithm and iterations for PBKDF2. The previous configuration, which relied on the defaults provided by crypto-es, posed potential security weaknesses due to less robust defaults.

#### Key Changes:
Switched to crypto-js: We have transitioned from using [crypto-es](https://github.com/entronad/crypto-es) to [crypto-js](https://github.com/brix/crypto-js). This decision was driven by the wider adoption and community support for [crypto-js](https://github.com/brix/crypto-js). Its extensive use in the industry makes it a more reliable choice for our cryptographic operations.

#### More info:
PBKDF2 is a key-derivation function that is used for two main purposes: (1) to stretch or squash a variable length password's entropy into a fixed size for consumption by another cryptographic operation and (2) to reduce the chance of downstream operations recovering the password input (for example, for password storage).

Unlike the modern [webcrypto](https://w3c.github.io/webcrypto/#pbkdf2-operations) standard, crypto-js does not throw an error when a number of iterations is not specified, and defaults to one single iteration. In the year 1993, when PBKDF2 was originally specified, the minimum number of iterations suggested was set at 1,000. Today, [OWASP recommends 1,300,000](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#pbkdf2)

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
